### PR TITLE
Add HTTPS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ghostblog CHANGELOG
 ===================
+Unreleased
+----------
+- Add SSL support (on by default).
+
 v1.0.5
 ------
 - Errors in config.js fixed.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Nginx settings
 * `node['ghost-blog']['nginx']['dir']` - Nginx directory. Default is `/etc/nginx`
 * `node['ghost-blog']['nginx']['script_dir']` - bin directory for scripts. Default is `/usr/bin`
 * `node['ghost-blog']['nginx']['server_name']` - Nginx server name. Default is `ghostblog.com`
+* `node['ghost-blog']['nginx']['ssl']` - `false` to disable SSL, `true` to enable (and redirect
+  http://yourblog.com to https://yourblog.com), and `:both` to enable both `http` and `https`
+  side-by-side without redirect. Default is `true`.
+* `node['ghost-blog']['nginx']['ssl_certificate']` - The certificate file to use. Self-signed
+  certificate will be generated if it does not exist. Default is `/etc/nginx/ssl/yourblog.com.crt`
+* `node['ghost-blog']['nginx']['ssl_certificate_key']` - The key used to sign the
+  certificate. Will be generated if it does not exist. Default is `/etc/nginx/ssl/yourblog.com.key`.
+* node['ghost-blog']['nginx']['self_signed_ssl_certificate_subj']` - If a self-signed certificate
+  is generated (which happens if you do not supply a certificate by placing the certificate in the
+  specified location), this is the information that will be used to fill it out. Default is
+  `/C=US/ST=Washington/L=Seattle/O=John Doe/OU=John Doe Industries/CN=*.yourblog.com/CN=yourblog.com`
 
 Ghost app settings
 ----------------
@@ -66,7 +77,7 @@ Ghost MySQL settings
 ## Note about MySQL option
 
 Creating a local MySQL server/database is outside the scope of this cookbook. I am assuming if you are using the `mysql` option for `node['ghost-blog']['app']['db_type']` that
-you already have a MySQL elsewhere such as AWS RDS or on another server. You could always wrap this cookbook and create your own MySQL instance. 
+you already have a MySQL elsewhere such as AWS RDS or on another server. You could always wrap this cookbook and create your own MySQL instance.
 
 * `node['ghost-blog']['mysql']['host']` - MySQL host. Default is `127.0.0.1`
 * `node['ghost-blog']['mysql']['user']` - MySQL user. Default is `ghost_blog`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,24 @@ default['ghost-blog']['version'] = 'latest'
 
 # Ghost Nginx settings
 default['ghost-blog']['nginx']['dir'] = '/etc/nginx'
+default['ghost-blog']['nginx']['log_dir'] = '/var/log/nginx'
 default['ghost-blog']['nginx']['script_dir'] = '/usr/sbin'
 default['ghost-blog']['nginx']['server_name'] = 'ghostblog.com'
+default['ghost-blog']['nginx']['http_port'] = 80
+default['ghost-blog']['nginx']['https_port'] = 443
+# Valid values: false, true, :both (doesn't redirect). Use both if you can't get
+# a certificate (startssl.com has free ones) and you want to get rid of the
+# warning for the self-signed cert.
+default['ghost-blog']['nginx']['ssl'] = true
+# We don't actually *set* this default: we calculate their values in the _nginx
+# recipe if you don't set them, so you can change server_name and affect these.
+# Generally, either ignore these or dump your certificate at
+# /etc/nginx/ssl/yourserver.com.crt and your key at yourserver.com.key, and you
+# are good.
+# default['ghost-blog']['nginx']['ssl_certificate'] = ...
+# default['ghost-blog']['nginx']['ssl_certificate_key'] = ...
+# Once again, the subj is auto-generated in the _nginx recipe so the hostname is right
+# default['ghost-blog']['app']['self_signed_ssl_certificate_subj'] = ...
 
 # Ghost app settings
 default['ghost-blog']['app']['server_url'] = 'localhost'

--- a/recipes/_ghost.rb
+++ b/recipes/_ghost.rb
@@ -1,3 +1,4 @@
+# TODO upgrade to latest ghost when there is a new one!
 remote_file "#{Chef::Config[:file_cache_path]}/ghost.zip" do
     source "https://ghost.org/zip/ghost-#{node['ghost-blog']['version']}.zip"
     not_if { ::File.exist?("#{Chef::Config[:file_cache_path]}/ghost.zip") }
@@ -14,6 +15,9 @@ nodejs_npm 'packages.json' do
     json true
     path node['ghost-blog']['install_dir']
     options ['--production']
+# TODO nodejs_npm seems like it's not really test-and-set. Fix that so we can
+# auto-restart ghost when the installation changes.
+#    notifies :restart, 'service[ghost]'
 end
 
 template '/etc/init.d/ghost' do
@@ -21,6 +25,7 @@ template '/etc/init.d/ghost' do
     owner 'root'
     group 'root'
     mode '0755'
+    notifies :restart, 'service[ghost]'
 end
 
 template "#{node['ghost-blog']['install_dir']}/config.js" do
@@ -43,5 +48,5 @@ template "#{node['ghost-blog']['install_dir']}/config.js" do
         :db_name => node['ghost-blog']['mysql']['database'],
         :charset => node['ghost-blog']['mysql']['charset']
     )
-    notifies :start, 'service[ghost]', :immediately
+    notifies :restart, 'service[ghost]'
 end

--- a/recipes/_nginx.rb
+++ b/recipes/_nginx.rb
@@ -1,3 +1,13 @@
+ require 'shellwords'
+
+ # Attribute defaults (done at this late date to take into account anything the
+ # user has set, such as server_name)
+ nginx_attrs = node['ghost-blog']['nginx'].to_h
+ nginx_attrs['ssl_certificate'] ||= "#{nginx_attrs['dir']}/ssl/#{nginx_attrs['server_name']}.crt"
+ nginx_attrs['ssl_certificate_key'] ||= "#{nginx_attrs['dir']}/ssl/#{nginx_attrs['server_name']}.key"
+ nginx_attrs['self_signed_ssl_certificate_subj'] ||= "/C=US/ST=Washington/L=Seattle/O=John Doe/OU=John Doe Industries/CN=*.#{nginx_attrs['server_name']}/CN=#{nginx_attrs['server_name']}"
+
+ # Bring in the latest stable nginx from apt (will not upgrade, though)
  apt_repository 'nginx' do
    uri          'ppa:nginx/stable'
    distribution node['lsb']['codename']
@@ -5,27 +15,44 @@
 
  package 'nginx'
 
+ # Utilities to enable and disable nginx sites
  %w{nxensite nxdissite}.each do |nxscript|
-     template "#{node['ghost-blog']['nginx']['script_dir']}/#{nxscript}" do
+   template "#{nginx_attrs['script_dir']}/#{nxscript}" do
      source "#{nxscript}.erb"
      mode '0755'
      owner 'root'
      group 'root'
    end
  end
- 
- template "/etc/nginx/sites-available/#{node['ghost-blog']['nginx']['server_name']}.conf" do
+
+ # Self-signed certificate (if needed)
+ execute "generate self-signed cert #{nginx_attrs['self_signed']}" do
+   command "openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout #{nginx_attrs['ssl_certificate_key'].to_s.shellescape} -out #{nginx_attrs['ssl_certificate'].to_s.shellescape} -subj #{nginx_attrs['self_signed_ssl_certificate_subj'].to_s.shellescape}"
+   # TODO regen or extend if expired
+   only_if do
+     # We don't overwrite keys and certificates. Not our jam, yo.
+     if nginx_attrs['ssl'] &&
+       !::File.exist?(nginx_attrs['ssl_certificate']) &&
+       !::File.exist?(nginx_attrs['ssl_certificate_key'])
+     end
+   end
+   notifies :restart, 'service[nginx]'
+ end
+
+ # Create the server definition
+ template "/etc/nginx/sites-available/#{nginx_attrs['server_name']}.conf" do
      source 'ghost.conf.erb'
+     variables nginx_attrs
      owner 'root'
      group 'root'
  end
 
+ # Enable the site
  bash 'enable site config' do
      user 'root'
      cwd '/etc/nginx/sites-available/'
      code <<-EOH
      nxdissite default
-     nxensite #{node['ghost-blog']['nginx']['server_name']}.conf
+     nxensite #{nginx_attrs['server_name']}.conf
      EOH
-     notifies :restart, 'service[nginx]', :immediately
  end

--- a/templates/default/ghost.conf.erb
+++ b/templates/default/ghost.conf.erb
@@ -1,7 +1,16 @@
 server {
+    server_name <%= @server_name %>;
+    access_log /var/log/nginx/<%= @server_name %>.log;
+    error_log /var/log/nginx/<%= @server_name %>_errors.log;
+<% if !@ssl || @ssl == :both %>
+    # If ssl is false or :both, ghost responds to http (no redirect)
     listen 80;
-    server_name <%= node['ghost-blog']['nginx']['server_name'] %>;
-    access_log /var/log/nginx/<%= node['ghost-blog']['nginx']['server_name'] %>.log;
+<% end %>
+<% if @ssl %>
+    listen 443 ssl;
+    ssl_certificate <%= @ssl_certificate %>;
+    ssl_certificate_key <%= @ssl_certificate_key %>;
+<% end %>
 
     location / {
         proxy_set_header X-Real-IP $remote_addr;
@@ -13,3 +22,12 @@ server {
         proxy_buffering off;
     }
 }
+
+<% if @ssl && @ssl != :both %>
+# if ssl is `true`, we redirect http to https
+server {
+    listen 80;
+    server_name <%= @server_name %>;
+    return 301 https://$server_name$request_uri;
+}
+<% end %>


### PR DESCRIPTION
This fixes #3. It:
1. Adds HTTPS support, on by default, listening at 443.
2. Redirects `http` to `https`.
3. Generates a self-signed certificate if no certificate is available.

This is necessary for the ghost API to work.  It should work out of the box with no cookbook modifications needed. Tested on Centos 7.
