### PR TITLE
node & kitchen updates

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,7 +17,15 @@ platforms:
   - name: ubuntu-14.04
     driver_config:
       network:
-      - ["private_network", {ip: 192.168.150.4}]
+      - ["private_network", {ip: 192.168.150.5}]
+      customize:
+        cpus: 4
+        memory: 4096
+
+  - name: ubuntu-16.04
+    driver_config:
+      network:
+      - ["private_network", {ip: 192.168.150.6}]
       customize:
         cpus: 4
         memory: 4096

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ghostblog CHANGELOG
 ===================
 
+v1.0.7
+------
+- Update repo url for node6.x versions.
+
 v1.0.6
 ----------
 - Add SSL support (on by default).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# node settings
+default['nodejs']['repo'] = 'https://deb.nodesource.com/node_6.x'
+
 # Ghost server settings
 default['ghost-blog']['install_dir'] = '/var/www/html/ghost'
 default['ghost-blog']['version'] = 'latest'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'c@cristhekid.com'
 license          'Apache 2.0'
 description      'Installs & configures Ghost: open source blogging platform'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.6'
+version          '1.0.7'
 
 %w( ubuntu ).each do |os|
     supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,9 @@ description      'Installs & configures Ghost: open source blogging platform'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.7'
 
+source_url 'https://github.com/arukaen/chef-ghost'
+issues_url 'https://github.com/arukaen/chef-ghost/issues'
+
 %w( ubuntu ).each do |os|
     supports os
 end


### PR DESCRIPTION
# What

- updates the repo url for node to install `6.9.1`
- adds xenial to the list of test-kitchens