### PR TITLE
Support custom includes in config.js

### DIFF
--- a/libraries/resource_blog.rb
+++ b/libraries/resource_blog.rb
@@ -66,6 +66,11 @@ class Chef
           notifies :restart, "service[ghost_#{sanitized_name}]"
         end
 
+        directory "#{install_dir}/includes" do
+          owner 'root'
+          group 'root'
+        end
+
         template "#{install_dir}/config.js" do
           source 'config.js.erb'
           cookbook 'ghost-blog'

--- a/libraries/resource_blog.rb
+++ b/libraries/resource_blog.rb
@@ -71,6 +71,12 @@ class Chef
           group 'root'
         end
 
+        template "#{install_dir}/includes/index.js" do
+          source 'index.js.erb'
+          owner 'root'
+          group 'root'
+        end
+
         template "#{install_dir}/config.js" do
           source 'config.js.erb'
           cookbook 'ghost-blog'

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -60,3 +60,5 @@ database: {
 };
 
 module.exports = config;
+
+require('/includes/*.js')()

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -61,4 +61,4 @@ database: {
 
 module.exports = config;
 
-require('/includes/*.js')()
+require('/includes/index.js')()

--- a/templates/default/config.js.erb
+++ b/templates/default/config.js.erb
@@ -61,4 +61,4 @@ database: {
 
 module.exports = config;
 
-require('/includes/index.js')()
+require('./includes/index.js')

--- a/templates/default/index.js.erb
+++ b/templates/default/index.js.erb
@@ -1,0 +1,2 @@
+// This file can be used to include custom imports into your config.js.
+// Simply use an `index.js.erb` template in your own cookbook.


### PR DESCRIPTION
`config.js` automatically includes all `.js` files that the user throws in the new `includes` directory that is created in the ghost install dir